### PR TITLE
Add SmartStubAdapter support to avoid vim.fault.NotAuthenticated

### DIFF
--- a/src/infi/pyvmomi_wrapper/client.py
+++ b/src/infi/pyvmomi_wrapper/client.py
@@ -1,5 +1,5 @@
 from pyVmomi import vim
-from .connect import Connect
+from .connect import Connect, get_smart_stub_instance
 from .errors import TimeoutException
 
 
@@ -9,11 +9,19 @@ def get_reference_to_managed_object(mo):
 
 
 class Client(object):
-    def __init__(self, vcenter_address, username=None, password=None, sdk_tunnel_host='sdkTunnel', sdk_tunnel_port=8089, certfile=None, keyfile=None, sslContext=None, protocol="https", port=443):
-        self.service_instance = Connect(vcenter_address, protocol=protocol, port=port,
-            user=username, pwd=password,
-            sdk_tunnel_host=sdk_tunnel_host, sdk_tunnel_port=sdk_tunnel_port,
-            certfile=certfile, keyfile=keyfile, sslContext=sslContext)
+    def __init__(self, vcenter_address, username=None, password=None, sdk_tunnel_host='sdkTunnel', sdk_tunnel_port=8089,
+                 certfile=None, keyfile=None, sslContext=None, protocol="https", port=443, use_smart_stub=False):
+        if use_smart_stub:
+            connection_kwargs = dict(username=username, password=password,
+                                     port=port, sslContext=sslContext, certKeyFile=certfile)
+            self.service_instance = get_smart_stub_instance(vcenter_address, **connection_kwargs)
+        else:
+            connection_kwargs = dict(protocol=protocol, port=port,
+                                     user=username, pwd=password, sdk_tunnel_host=sdk_tunnel_host,
+                                     sdk_tunnel_port=sdk_tunnel_port,
+                                     certfile=certfile, keyfile=keyfile, sslContext=sslContext)
+            self.service_instance = Connect(vcenter_address, **connection_kwargs)
+        self.smart_stub = use_smart_stub
         self.service_content = self.service_instance.content
         self.session_manager = self.service_content.sessionManager
         self.root = self.service_content.rootFolder

--- a/src/infi/pyvmomi_wrapper/connect.py
+++ b/src/infi/pyvmomi_wrapper/connect.py
@@ -1,6 +1,7 @@
 # Copy of SmartConnect + Connect, but login is optional and keyfile/certfile passed all the way
 
-from pyVim.connect import GetServiceVersions, __FindSupportedVersion, SoapStubAdapter
+from pyVim.connect import (GetServiceVersions, __FindSupportedVersion, SoapStubAdapter, SmartStubAdapter,
+                           VimSessionOrientedStub)
 from pyVim.connect import versionMap, _rx
 from .format_object import FormatObject
 from pyVmomi import vim
@@ -141,3 +142,12 @@ def Connect(host, protocol="https", port=443, user=None, pwd=None,
         content.sessionManager.Login(user, pwd, None)
 
     return si
+
+
+def get_smart_stub_instance(vcenter_address, username=None, password=None, **kwargs):
+    """
+    https://github.com/vmware/pyvmomi/issues/347
+    """
+    smart_stub = SmartStubAdapter(host=vcenter_address, connectionPoolTimeout=0, **kwargs)
+    session_stub = VimSessionOrientedStub(smart_stub, VimSessionOrientedStub.makeUserLoginMethod(username, password))
+    return vim.ServiceInstance('ServiceInstance', session_stub)

--- a/src/infi/pyvmomi_wrapper/sms/client.py
+++ b/src/infi/pyvmomi_wrapper/sms/client.py
@@ -8,7 +8,8 @@ class SmsClient(object):
     def __init__(self, client, version="version4"):
         import re
         # https://github.com/vmware/pyvmomi/pull/165#issuecomment-213623822
-        client_stub = client.service_instance._GetStub()
+        client_stub = client.service_instance._GetStub().soapStub\
+            if client.smart_stub else client.service_instance._GetStub()  # pylint: disable=protected-access
         session_cookie = client_stub.cookie.split('"')[1]
         ssl_context = client_stub.schemeArgs.get('context')
         additional_headers = {'vcSessionCookie': session_cookie}


### PR DESCRIPTION
Add SmartStubAdapter support to avoid vim.fault.NotAuthenticated exception in case of idle timeouts. This is according to solution specified here: https://github.com/vmware/pyvmomi/issues/347