### PR TITLE
Update `DictMixIn` import.

### DIFF
--- a/src/infi/pyvmomi_wrapper/resources.py
+++ b/src/infi/pyvmomi_wrapper/resources.py
@@ -1,8 +1,13 @@
 from pyVmomi import vim
 try:
-    from UserDict import DictMixin
+    from collections.abc import MutableMapping as DictMixin
 except ImportError:
-    from collections import MutableMapping as DictMixin
+    try:
+        # Older alternative.  Removed in python 3.10.
+        from collections import MutableMapping as DictMixin
+    except ImportError:
+        # Even older alternative.  Deprecated in python 2.6.
+        from UserDict import DictMixin
 from infi.pyutils.lazy import clear_cache, cached_method
 from json import dumps, loads
 


### PR DESCRIPTION
Here's a change I'd like to suggest.  The code in `resources.py`
imports `DictMixIn` in one of two ways: the python 2.x way, and if
that fails, the python 3.x way.

Unfortunately that python 3.x way has now been replaced with a _new_
python 3.x way, and the next major python release will drop the
compatibility shim.

So, this change tries all _three_ ways of importing `DictMixIn`.  And
also, because I figured it'd make sense, it tries the most modern import
first.  Only when that fails does it fall back on the older way, and if
that fails, it goes all the way back to the 2.x way.

(Of course this assumes that the old import is still useful.  If not,
things could be a lot simpler.)